### PR TITLE
Windows Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - No external dependencies <img src="https://media.giphy.com/media/9xghOCloQOsAfq9hUg/giphy.gif" align="right">
 - Minimal and colorful output 🌈
-- Works on **Linux** and **MacOS**
+- Works on **Linux**, **MacOS**, and **Windows**
 - Only **4KB**
 - Written by me 😉
 <br>

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ pip3 install --user gitdir
 
 ## Usage
 ```
-usage: gitdir.py [-h] url
+usage: gitdir [-h] [--flatten] url
 
 Download directories/folders from GitHub
 
@@ -27,8 +27,11 @@ positional arguments:
   url
 
 optional arguments:
-  -h, --help  show this help message and exit
+  -h, --help     show this help message and exit
+  --flatten, -f  Flatten directory structures. Do not create extra directory
+                 and download found files to current directory.
 ```
+
 **Exiting**
 
 To exit the program, just press ```CTRL+C```.

--- a/gitdir/__main__.py
+++ b/gitdir/__main__.py
@@ -1,0 +1,1 @@
+from .gitdir import main

--- a/gitdir/gitdir
+++ b/gitdir/gitdir
@@ -5,6 +5,7 @@ import urllib.request
 import signal
 import argparse
 import json
+import sys
 
 # this ANSI code lets us erase the current line
 ERASE_LINE = "\x1b[2K"
@@ -89,8 +90,9 @@ def download(repo_url, flatten):
 
 
 def main():
-    # disbale CTRL+Z
-    signal.signal(signal.SIGTSTP, signal.SIG_IGN)
+    if sys.platform != 'win32':
+        # disbale CTRL+Z
+        signal.signal(signal.SIGTSTP, signal.SIG_IGN)
 
     parser = argparse.ArgumentParser(description="Download directories/folders from GitHub")
     parser.add_argument('url', action="store")

--- a/gitdir/gitdir.py
+++ b/gitdir/gitdir.py
@@ -97,7 +97,9 @@ def main():
     parser = argparse.ArgumentParser(description="Download directories/folders from GitHub")
     parser.add_argument('url', action="store")
 
-    parser.add_argument('--flatten', '-f', action="store_true", help='flatten directory structures')
+    parser.add_argument('--flatten', '-f', action="store_true", help='Flatten directory structures. Do not create extra'
+                                                                     ' directory and download found files to current'
+                                                                     ' directory.')
 
     args = parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='gitdir',
-    version='1.1.3',
+    version='1.1.4',
     author='Siddharth Dushantha',
     author_email='siddharth.dushantha@gmail.com',
     description='Download a single directory/folder from a GitHub repo',
@@ -13,5 +13,9 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/sdushantha/gitdir',
     py_modules=['gitdir'],
-    scripts=['gitdir/gitdir']
+    entry_points={
+        'console_scripts': [
+            'gitdir = gitdir.gitdir:main',
+        ]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/sdushantha/gitdir',
-    py_modules=['gitdir'],
+    packages=setuptools.find_packages(),
     entry_points={
         'console_scripts': [
-            'gitdir = gitdir.gitdir:main',
+            'gitdir = gitdir.__main__:main',
         ]
     }
 )


### PR DESCRIPTION
Hi, previously this does not work on Windows. setup script was written in a way that only worked on unix systems. I fixed setup script so that command installation works on MacOS, Linux, and Windows systems, all three I tested on physical machine.

Also the `signal.signal(signal.SIGTSTP, signal.SIG_IGN)` does not work on Windows and will cause execution to error. I write code to skip that on Windows systems.

See [python documentation](https://docs.python.org/3/library/signal.html#signal.signal)
> On Windows, signal() can only be called with SIGABRT, SIGFPE, SIGILL, SIGINT, SIGSEGV, SIGTERM, or SIGBREAK. A ValueError will be raised in any other case. Note that not all systems define the same set of signal names; an AttributeError will be raised if a signal name is not defined as SIG* module level constant.