### PR TITLE
Windows compatibility. Dependency packaging.

### DIFF
--- a/gitdir/gitdir.py
+++ b/gitdir/gitdir.py
@@ -6,10 +6,28 @@ import signal
 import argparse
 import json
 import sys
-from colorama import Fore, Style
+from colorama import Fore, Style, init
+
+init()
 
 # this ANSI code lets us erase the current line
 ERASE_LINE = "\x1b[2K"
+
+COLOR_NAME_TO_CODE = {"default": "", "red": Fore.RED, "green": Style.BRIGHT + Fore.GREEN}
+
+
+def print_text(text, color="default", in_place=False, **kwargs):  # type: (str, str, bool, any) -> None
+    """
+    print text to console, a wrapper to built-in print
+
+    :param text: text to print
+    :param color: can be one of "red" or "green", or "default"
+    :param in_place: whether to erase previous line and print in place
+    :param kwargs: other keywords passed to built-in print
+    """
+    if in_place:
+        print("\r" + ERASE_LINE, end="")
+    print(COLOR_NAME_TO_CODE[color] + text + Style.RESET_ALL, **kwargs)
 
 
 def create_url(url):
@@ -46,9 +64,7 @@ def download(repo_url, flatten):
     except KeyboardInterrupt:
         # when CTRL+C is pressed during the execution of this script,
         # bring the cursor to the beginning, erase the current line, and dont make a new line
-        print("\r" + ERASE_LINE, end="")
-
-        print(Fore.RED + "✘ Got interupted")
+        print_text("✘ Got interrupted", "red", in_place=True)
         exit()
 
     if not flatten:
@@ -83,15 +99,13 @@ def download(repo_url, flatten):
                     urllib.request.urlretrieve(file_url, path)
 
                     # bring the cursor to the beginning, erase the current line, and dont make a new line
-                    print("\r" + ERASE_LINE, end="")
-                    print(Fore.GREEN + "Downloaded: " + Fore.WHITE + "{}".format(fname), end="", flush=True)
+                    print_text("Downloaded: " + Fore.WHITE + "{}".format(fname), "green", in_place=True, end="",
+                               flush=True)
 
                 except KeyboardInterrupt:
                     # when CTRL+C is pressed during the execution of this script,
                     # bring the cursor to the beginning, erase the current line, and dont make a new line
-                    print("\r" + ERASE_LINE, end="")
-
-                    print(Fore.RED + "✘ Got interupted")
+                    print_text("✘ Got interrupted", 'red', in_place=True)
                     exit()
             else:
                 download(file["html_url"], flatten)
@@ -118,8 +132,7 @@ def main():
 
     total_files = download(repo_url, flatten)
 
-    print("\r" + ERASE_LINE, end="")
-    print("\033[1;92m✔ Download complete\033[0m")
+    print_text("✔ Download complete", "green", in_place=True)
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ setuptools.setup(
         'console_scripts': [
             'gitdir = gitdir.__main__:main',
         ]
-    }
+    },
+    install_requires=['colorama~=0.4']
 )


### PR DESCRIPTION
Hi, there is a big oopsies! `colorama` needs to be specified in `setup.py` to get installed on users machine. Otherwise they'll get errors if they don't have colorama already installed

```
(venv) PS F:\> pip install -e D:\PycharmProjects\gitdir
Obtaining file:///D:/PycharmProjects/gitdir
Installing collected packages: gitdir
  Running setup.py develop for gitdir
Successfully installed gitdir
(venv) PS F:\> gitdir
Traceback (most recent call last):
  File "F:\venv\Scripts\gitdir-script.py", line 11, in <module>
    load_entry_point('gitdir', 'console_scripts', 'gitdir')()
  File "f:\venv\lib\site-packages\pkg_resources\__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "f:\venv\lib\site-packages\pkg_resources\__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "f:\venv\lib\site-packages\pkg_resources\__init__.py", line 2443, in load
    return self.resolve()
  File "f:\venv\lib\site-packages\pkg_resources\__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "d:\pycharmprojects\gitdir\gitdir\__main__.py", line 1, in <module>
    from .gitdir import main
  File "d:\pycharmprojects\gitdir\gitdir\gitdir.py", line 9, in <module>
    from colorama import Fore, Style
```

Also I added `colorama.init()` call for windows compatibility,

here from coloramas [docs](https://github.com/tartley/colorama):
> On Windows, calling init() will filter ANSI escape sequences out of any text sent to stdout or stderr, and replace them with equivalent Win32 calls.
On other platforms, calling init() has no effect (unless you request other optional functionality; see "Init Keyword Args", below). By design, this permits applications to call init() unconditionally on all platforms, after which ANSI output should just work.

Did a little refactoring too. Worth mentioning, I believe the code you use was "bright + green", so I went along with that. the picture is a comparison of "green" and "bright + green" on Windows.
<img width="651" alt="debug" src="https://user-images.githubusercontent.com/44753941/70393640-5dace200-19a9-11ea-91a0-104f50c6dd26.PNG">
Sorry for the debug message in between, that's my favorite casual debug message 😄 

A last bit to mention is I added "Style.RESET_ALL" after those colorful texts, otherwise following text color may get polluted. (btw the debug message was to testing that)

Oh and the ticks from the previous picture is not rendered, I'm not sure why they don't render properly on my Windows powershell terminal. It may be my system not configured for Unicode. Might investigate later. I remember the tick definitely looked right when I used gitdir on Linux.


