### PR TITLE
Add package entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ optional arguments:
                  and download found files to current directory.
 ```
 
+## Packge Entry
+
+You can use `python -m gitdir` / `python3 -m gitdir` in case the short command does not work.
+
 **Exiting**
 
 To exit the program, just press ```CTRL+C```.

--- a/gitdir/__main__.py
+++ b/gitdir/__main__.py
@@ -1,1 +1,3 @@
 from .gitdir import main
+
+main()


### PR DESCRIPTION
Hi, was trying the package entry today `python3 -m gitdir` and it exits without output.
 
Turns out I forgot to add `main()` call in `__main__.py` when I submitted the pull request the other day.

Just a note: the need to use `python -m` is quite common as far as I know. On Windows systems, `python/Scripts` (counterpart of bin folders in unix systems) is not by default added to system path, so `gitdirs` won't be registered as available command to run. It also happens when multiple versions of python are installed, as `gitdirs` may be installed with a particular python version (say `python3.6 -m gitdirs ...`)

