### PR TITLE
--flatten bug fix | Double run bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,22 @@ $ pip3 install --user gitdir
 
 ## Usage
 ```
-usage: gitdir [-h] [--flatten] url
+usage: gitdir [-h] [--output_dir OUTPUT_DIR] [--flatten] urls [urls ...]
 
 Download directories/folders from GitHub
 
 positional arguments:
-  url
+  urls                  List of Github directories to download.
 
 optional arguments:
-  -h, --help     show this help message and exit
-  --flatten, -f  Flatten directory structures. Do not create extra directory
-                 and download found files to current directory.
+  -h, --help            show this help message and exit
+  --output_dir OUTPUT_DIR, -d OUTPUT_DIR
+                        All directories will be downloaded to the specified
+                        directory.
+  --flatten, -f         Flatten directory structures. Do not create extra
+                        directory and download found files to output
+                        directory. (default to current directory if not
+                        specified)
 ```
 
 ## Packge Entry

--- a/gitdir/gitdir.py
+++ b/gitdir/gitdir.py
@@ -111,8 +111,12 @@ def download(repo_url, flatten=False, output_dir="./"):
                 path = os.path.basename(file["path"])
             else:
                 path = file["path"]
+            dirname = os.path.dirname(path)
 
-            os.makedirs(os.path.dirname(path), exist_ok=True)
+            if dirname != '':
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+            else:
+                pass
 
             if file_url is not None:
                 try:
@@ -150,7 +154,7 @@ def main():
 
     parser.add_argument('--flatten', '-f', action="store_true",
                         help='Flatten directory structures. Do not create extra directory and download found files to'
-                             ' current directory.')
+                             ' output directory. (default to current directory if not specified)')
 
     args = parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     entry_points={
         'console_scripts': [
-            'gitdir = gitdir.__main__:main',
+            'gitdir = gitdir.gitdir:main',
         ]
     },
     install_requires=['colorama~=0.4']


### PR DESCRIPTION
Currently `gitdir --flatten <url>` errors out, while it's supposed to download remote files without directory structure directly under current directory.

Example error output:

```
$ gitdir -f https://github.com/UAlbertaALTLab/cree-intelligent-dictionary/tree/master/docs/images
Traceback (most recent call last):
  File "/home/matt/PycharmProjects/gitdir/venv/bin/gitdir", line 11, in <module>
    load_entry_point('gitdir', 'console_scripts', 'gitdir')()
  File "/home/matt/PycharmProjects/gitdir/venv/lib/python3.7/site-packages/setuptools-40.8.0-py3.7.egg/pkg_resources/__init__.py", line 489, in load_entry_point
  File "/home/matt/PycharmProjects/gitdir/venv/lib/python3.7/site-packages/setuptools-40.8.0-py3.7.egg/pkg_resources/__init__.py", line 2793, in load_entry_point
  File "/home/matt/PycharmProjects/gitdir/venv/lib/python3.7/site-packages/setuptools-40.8.0-py3.7.egg/pkg_resources/__init__.py", line 2411, in load
  File "/home/matt/PycharmProjects/gitdir/venv/lib/python3.7/site-packages/setuptools-40.8.0-py3.7.egg/pkg_resources/__init__.py", line 2417, in resolve
  File "/home/matt/PycharmProjects/gitdir/gitdir/__main__.py", line 3, in <module>
    main()
  File "/home/matt/PycharmProjects/gitdir/gitdir/gitdir.py", line 159, in main
    total_files = download(url, flatten, args.output_dir)
  File "/home/matt/PycharmProjects/gitdir/gitdir/gitdir.py", line 115, in download
    os.makedirs(os.path.dirname(path), exist_ok=True)
  File "/usr/lib/python3.7/os.py", line 221, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''
```

And It can be fixed by adding a single check.



The other bug is that the downloading runs twice due to misconfiguration of setup.py, doubling the download time. Here's the before & after of the fix:

![Screenshot from 2020-06-02 07-04-32](https://user-images.githubusercontent.com/44753941/83523666-bd3f0280-a49f-11ea-8c06-1173317c74a3.png)
