### PR TITLE
Prompt before overwriting files, some error handling, and refactoring

### DIFF
--- a/gitdir/gitdir.py
+++ b/gitdir/gitdir.py
@@ -13,10 +13,14 @@ init()
 # this ANSI code lets us erase the current line
 ERASE_LINE = "\x1b[2K"
 
-COLOR_NAME_TO_CODE = {"default": "", "red": Fore.RED, "green": Style.BRIGHT + Fore.GREEN}
+COLOR_NAME_TO_CODE = {
+    "default": "",
+    "red": Fore.RED,
+    "green": Style.BRIGHT + Fore.GREEN,
+}
 
 
-def print_text(text, color="default", in_place=False, **kwargs):  # type: (str, str, bool, any) -> None
+def print_text(text, color="default", in_place=False, **kwargs) -> None:
     """
     print text to console, a wrapper to built-in print
 
@@ -34,27 +38,37 @@ def create_url(url):
     """
     From the given url, produce a URL that is compatible with Github's REST API. Can handle blob or tree paths.
     """
-    repo_only_url = re.compile(r"https:\/\/github\.com\/[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}\/[a-zA-Z0-9]+$")
+    repo_only_url = re.compile(
+        r"https:\/\/github\.com\/[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}\/[a-zA-Z0-9]+$"
+    )
     re_branch = re.compile("/(tree|blob)/(.+?)/")
 
     # Check if the given url is a url to a GitHub repo. If it is, tell the
     # user to use 'git clone' to download it
-    if re.match(repo_only_url,url):
-        print_text("✘ The given url is a complete repository. Use 'git clone' to download the repository",
-                   "red", in_place=True)
+    if re.match(repo_only_url, url):
+        print_text(
+            "✘ The given url is a complete repository. Use 'git clone' to download the repository",
+            "red",
+            in_place=True,
+        )
         sys.exit()
 
     # extract the branch name from the given url (e.g master)
     branch = re_branch.search(url)
-    download_dirs = url[branch.end():]
-    api_url = (url[:branch.start()].replace("github.com", "api.github.com/repos", 1) +
-              "/contents/" + download_dirs + "?ref=" + branch.group(2))
+    download_dirs = url[branch.end() :]
+    api_url = (
+        url[: branch.start()].replace("github.com", "api.github.com/repos", 1)
+        + "/contents/"
+        + download_dirs
+        + "?ref="
+        + branch.group(2)
+    )
     return api_url, download_dirs
 
 
 def download(repo_url, flatten=False, output_dir="./"):
-    """ Downloads the files and directories in repo_url. If flatten is specified, the contents of any and all
-     sub-directories will be pulled upwards into the root folder. """
+    """Downloads the files and directories in repo_url. If flatten is specified, the contents of any and all
+    sub-directories will be pulled upwards into the root folder."""
 
     # generate the url which returns the JSON data
     api_url, download_dirs = create_url(repo_url)
@@ -70,7 +84,7 @@ def download(repo_url, flatten=False, output_dir="./"):
 
     try:
         opener = urllib.request.build_opener()
-        opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+        opener.addheaders = [("User-agent", "Mozilla/5.0")]
         urllib.request.install_opener(opener)
         response = urllib.request.urlretrieve(api_url)
     except KeyboardInterrupt:
@@ -98,17 +112,23 @@ def download(repo_url, flatten=False, output_dir="./"):
             try:
                 # download the file
                 opener = urllib.request.build_opener()
-                opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+                opener.addheaders = [("User-agent", "Mozilla/5.0")]
                 urllib.request.install_opener(opener)
-                urllib.request.urlretrieve(data["download_url"], os.path.join(dir_out, data["name"]))
+                urllib.request.urlretrieve(
+                    data["download_url"], os.path.join(dir_out, data["name"])
+                )
                 # bring the cursor to the beginning, erase the current line, and dont make a new line
-                print_text("Downloaded: " + Fore.WHITE + "{}".format(data["name"]), "green", in_place=True)
+                print_text(
+                    "Downloaded: " + Fore.WHITE + "{}".format(data["name"]),
+                    "green",
+                    in_place=True,
+                )
 
                 return total_files
             except KeyboardInterrupt:
                 # when CTRL+C is pressed during the execution of this script,
                 # bring the cursor to the beginning, erase the current line, and dont make a new line
-                print_text("✘ Got interrupted", 'red', in_place=False)
+                print_text("✘ Got interrupted", "red", in_place=False)
                 sys.exit()
 
         for file in data:
@@ -122,7 +142,7 @@ def download(repo_url, flatten=False, output_dir="./"):
                 path = file_path
             dirname = os.path.dirname(path)
 
-            if dirname != '':
+            if dirname != "":
                 os.makedirs(os.path.dirname(path), exist_ok=True)
             else:
                 pass
@@ -130,19 +150,24 @@ def download(repo_url, flatten=False, output_dir="./"):
             if file_url is not None:
                 try:
                     opener = urllib.request.build_opener()
-                    opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+                    opener.addheaders = [("User-agent", "Mozilla/5.0")]
                     urllib.request.install_opener(opener)
                     # download the file
                     urllib.request.urlretrieve(file_url, path)
 
                     # bring the cursor to the beginning, erase the current line, and dont make a new line
-                    print_text("Downloaded: " + Fore.WHITE + "{}".format(file_name), "green", in_place=False, end="\n",
-                               flush=True)
+                    print_text(
+                        "Downloaded: " + Fore.WHITE + "{}".format(file_name),
+                        "green",
+                        in_place=False,
+                        end="\n",
+                        flush=True,
+                    )
 
                 except KeyboardInterrupt:
                     # when CTRL+C is pressed during the execution of this script,
                     # bring the cursor to the beginning, erase the current line, and dont make a new line
-                    print_text("✘ Got interrupted", 'red', in_place=False)
+                    print_text("✘ Got interrupted", "red", in_place=False)
                     sys.exit()
             else:
                 download(file["html_url"], flatten, download_dirs)
@@ -151,19 +176,31 @@ def download(repo_url, flatten=False, output_dir="./"):
 
 
 def main():
-    if sys.platform != 'win32':
+    if sys.platform != "win32":
         # disbale CTRL+Z
         signal.signal(signal.SIGTSTP, signal.SIG_IGN)
 
-    parser = argparse.ArgumentParser(description="Download directories/folders from GitHub")
-    parser.add_argument('urls', nargs="+",
-                        help="List of Github directories to download.")
-    parser.add_argument('--output_dir', "-d", dest="output_dir", default="./",
-                        help="All directories will be downloaded to the specified directory.")
+    parser = argparse.ArgumentParser(
+        description="Download directories/folders from GitHub"
+    )
+    parser.add_argument(
+        "urls", nargs="+", help="List of Github directories to download."
+    )
+    parser.add_argument(
+        "--output_dir",
+        "-d",
+        dest="output_dir",
+        default="./",
+        help="All directories will be downloaded to the specified directory.",
+    )
 
-    parser.add_argument('--flatten', '-f', action="store_true",
-                        help='Flatten directory structures. Do not create extra directory and download found files to'
-                             ' output directory. (default to current directory if not specified)')
+    parser.add_argument(
+        "--flatten",
+        "-f",
+        action="store_true",
+        help="Flatten directory structures. Do not create extra directory and download found files to"
+        " output directory. (default to current directory if not specified)",
+    )
 
     args = parser.parse_args()
 

--- a/gitdir/gitdir.py
+++ b/gitdir/gitdir.py
@@ -55,6 +55,11 @@ def create_url(url):
 
     # extract the branch name from the given url (e.g master)
     branch = re_branch.search(url)
+    if branch is None:
+        print_text(
+            "✘ Could not find branch name in the given url", "red", in_place=True
+        )
+        sys.exit()
     download_dirs = url[branch.end() :]
     api_url = (
         url[: branch.start()].replace("github.com", "api.github.com/repos", 1)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='gitdir',
-    version='1.2.7',
+    version='1.2.8',
     author='Siddharth Dushantha',
     author_email='siddharth.dushantha@gmail.com',
     description='Download a single directory/folder from a GitHub repo',


### PR DESCRIPTION
Fix #33

```
/tmp via 🐍 v3.12.0 via 💎 v3.2.2 took 10ms
01:49:51 AM ➜ mkdir test_env

/tmp via 🐍 v3.12.0 via 💎 v3.2.2 took 2ms
01:49:56 AM ➜ cd test_env/

/tmp/test_env via 💎 v3.2.2 took 20ms
01:49:58 AM ➜ ls

/tmp/test_env via 💎 v3.2.2 took 4ms
01:49:58 AM ➜ gitdir https://github.com/sdushantha/gitdir/tree/master/gitdir
Downloaded: __init__.py to gitdir/__init__.py
Downloaded: __main__.py to gitdir/__main__.py
Downloaded: gitdir.py to gitdir/gitdir.py
✔ Download complete

/tmp/test_env via 💎 v3.2.2 took 2s
01:50:40 AM ➜ gitdir https://github.com/sdushantha/gitdir/tree/master/gitdir
✘ File gitdir/__init__.py already exists. Overwrite? [y/N] y
Downloading (overwriting): __init__.py to /tmp/test_env/gitdir/__init__.py
✘ File gitdir/__main__.py already exists. Overwrite? [y/N] y
Downloading (overwriting): __main__.py to /tmp/test_env/gitdir/__main__.py
✘ File gitdir/gitdir.py already exists. Overwrite? [y/N] N
Skipped: gitdir.py
✔ Download complete

/tmp/test_env via 💎 v3.2.2 took 6s
01:50:49 AM ➜ ls
 gitdir

/tmp/test_env via 💎 v3.2.2 took 4ms
01:51:01 AM ➜ ll gitdir
.rw-rw-r-- alichtman alichtman  16 B  Sat Jan 13 2024 01:50:46 AM  __init__.py
.rw-rw-r-- alichtman alichtman  33 B  Sat Jan 13 2024 01:50:47 AM  __main__.py
.rw-rw-r-- alichtman alichtman 6.8 KB Sat Jan 13 2024 01:50:40 AM  gitdir.py
```

Single file downloads still work:

```
/tmp/test_env via 💎 v3.2.2 took 4ms
01:51:16 AM ➜ gitdir https://github.com/sdushantha/gitdir/blob/master/setup.py
Single file download
Downloaded: setup.py to setup.py
✔ Download complete

/tmp/test_env via 🐍 v3.12.0 via 💎 v3.2.2 took 657ms
01:53:41 AM ➜ head setup.py
import setuptools

with open('README.md', 'r') as fh:
    long_description = fh.read()

setuptools.setup(
    name='gitdir',
    version='1.2.7',
    author='Siddharth Dushantha',
    author_email='siddharth.dushantha@gmail.com',
```